### PR TITLE
Enable EKS for int-production prod primary

### DIFF
--- a/Terraform/deployments/int-production/Tenant-account/prod/primary/terragrunt.hcl
+++ b/Terraform/deployments/int-production/Tenant-account/prod/primary/terragrunt.hcl
@@ -36,19 +36,19 @@ locals {
   vpc_name     = "production"
   vpc_name_abr = "prod"
   ## eks related variables
-  create_eks_cluster      = false
-  create_node_group       = false
-  create_service_accounts = false
-  enable_eks_pia          = false
-  create_rbac             = false
-  create_namespaces       = false
-  enable_karpenter        = false
+  create_eks_cluster      = true
+  create_node_group       = true
+  create_service_accounts = true
+  enable_eks_pia          = true
+  create_rbac             = true
+  create_namespaces       = true
+  enable_karpenter        = true
   ## eks monitoring
   create_opensearch               = false
   create_firehose                 = false
   enable_fluent_bit               = false # Set to true to enable Fluent Bit logging. When enabled, logs are sent to Firehose → OpenSearch (requires create_firehose = true and create_opensearch = true)
-  enable_cloudwatch_observability = false # Set to false if enabling fluent bit plus firehose → opensearch
-  enable_kube_prometheus_stack    = false
+  enable_cloudwatch_observability = true  # Set to false if enabling fluent bit plus firehose → opensearch
+  enable_kube_prometheus_stack    = true
   ## other variables
   create_ecs_cluster  = false
   create_postgres_rds = false


### PR DESCRIPTION
## Summary
Enable EKS in `Terraform/deployments/int-production/Tenant-account/prod/primary/terragrunt.hcl` for the `intp` production tenant deployment.

## Changes
- enable EKS cluster, node group, service accounts, PIA, RBAC, namespaces, and Karpenter
- enable CloudWatch observability
- enable kube-prometheus-stack
- keep OpenSearch and Firehose disabled

## Validation
- `terragrunt hclfmt`
- local `terragrunt validate` reached environment blockers only: missing local `TF_VAR_*` env vars and a `403` reading shared-account remote state
